### PR TITLE
Fix assets TypeScript SDK v2 URLs

### DIFF
--- a/typescript/assets-api/common.ts
+++ b/typescript/assets-api/common.ts
@@ -119,9 +119,35 @@ export const toPathString = function (url: URL) {
     return url.pathname + url.search + url.hash
 }
 
+const ASSETS_API_BASE_PATH = "https://assets.deadlock-api.com";
+const CANONICAL_VERSIONED_ASSETS_API_BASE_PATH = "https://api.deadlock-api.com/v1/assets";
+
+function normalizeBasePath(basePath?: string) {
+    return (basePath ?? "").replace(/\/+$/, "");
+}
+
+function createRequestUrl(axios: AxiosInstance, requestPath: string, configuredBasePath: string) {
+    const axiosBasePath = typeof axios.defaults.baseURL === "string" ? normalizeBasePath(axios.defaults.baseURL) : "";
+    const normalizedConfiguredBasePath = normalizeBasePath(configuredBasePath);
+    const effectiveBasePath = axiosBasePath || normalizedConfiguredBasePath;
+
+    if (requestPath.startsWith("/v2/")) {
+        const canonicalPath = requestPath.slice("/v2".length);
+        if (effectiveBasePath === ASSETS_API_BASE_PATH) {
+            return `${CANONICAL_VERSIONED_ASSETS_API_BASE_PATH}${canonicalPath}`;
+        }
+        if (effectiveBasePath === CANONICAL_VERSIONED_ASSETS_API_BASE_PATH) {
+            return axiosBasePath ? canonicalPath : `${normalizedConfiguredBasePath}${canonicalPath}`;
+        }
+    }
+
+    return `${axiosBasePath ? "" : configuredBasePath}${requestPath}`;
+}
+
 export const createRequestFunction = function (axiosArgs: RequestArgs, globalAxios: AxiosInstance, BASE_PATH: string, configuration?: Configuration) {
     return <T = unknown, R = AxiosResponse<T>>(axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-        const axiosRequestArgs = {...axiosArgs.options, url: (axios.defaults.baseURL ? '' : configuration?.basePath ?? basePath) + axiosArgs.url};
+        const configuredBasePath = configuration?.basePath ?? basePath;
+        const axiosRequestArgs = {...axiosArgs.options, url: createRequestUrl(axios, axiosArgs.url, configuredBasePath)};
         return axios.request<T, R>(axiosRequestArgs);
     };
 }

--- a/typescript/patch.mjs
+++ b/typescript/patch.mjs
@@ -28,6 +28,59 @@ function addJsExtensions(dir) {
   }
 }
 
+function patchAssetsApiClient(dir, pkg) {
+  if (pkg.name !== "assets_deadlock_api_client") return;
+
+  const commonPath = resolve(dir, "common.ts");
+  const common = readFileSync(commonPath, "utf8");
+  if (common.includes("CANONICAL_VERSIONED_ASSETS_API_BASE_PATH")) return;
+
+  const original = `export const createRequestFunction = function (axiosArgs: RequestArgs, globalAxios: AxiosInstance, BASE_PATH: string, configuration?: Configuration) {
+    return <T = unknown, R = AxiosResponse<T>>(axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+        const axiosRequestArgs = {...axiosArgs.options, url: (axios.defaults.baseURL ? '' : configuration?.basePath ?? basePath) + axiosArgs.url};
+        return axios.request<T, R>(axiosRequestArgs);
+    };
+}`;
+  const replacement = `const ASSETS_API_BASE_PATH = "https://assets.deadlock-api.com";
+const CANONICAL_VERSIONED_ASSETS_API_BASE_PATH = "https://api.deadlock-api.com/v1/assets";
+
+function normalizeBasePath(basePath?: string) {
+    return (basePath ?? "").replace(/\\/+$/, "");
+}
+
+function createRequestUrl(axios: AxiosInstance, requestPath: string, configuredBasePath: string) {
+    const axiosBasePath = typeof axios.defaults.baseURL === "string" ? normalizeBasePath(axios.defaults.baseURL) : "";
+    const normalizedConfiguredBasePath = normalizeBasePath(configuredBasePath);
+    const effectiveBasePath = axiosBasePath || normalizedConfiguredBasePath;
+
+    if (requestPath.startsWith("/v2/")) {
+        const canonicalPath = requestPath.slice("/v2".length);
+        if (effectiveBasePath === ASSETS_API_BASE_PATH) {
+            return \`\${CANONICAL_VERSIONED_ASSETS_API_BASE_PATH}\${canonicalPath}\`;
+        }
+        if (effectiveBasePath === CANONICAL_VERSIONED_ASSETS_API_BASE_PATH) {
+            return axiosBasePath ? canonicalPath : \`\${normalizedConfiguredBasePath}\${canonicalPath}\`;
+        }
+    }
+
+    return \`\${axiosBasePath ? "" : configuredBasePath}\${requestPath}\`;
+}
+
+export const createRequestFunction = function (axiosArgs: RequestArgs, globalAxios: AxiosInstance, BASE_PATH: string, configuration?: Configuration) {
+    return <T = unknown, R = AxiosResponse<T>>(axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+        const configuredBasePath = configuration?.basePath ?? basePath;
+        const axiosRequestArgs = {...axiosArgs.options, url: createRequestUrl(axios, axiosArgs.url, configuredBasePath)};
+        return axios.request<T, R>(axiosRequestArgs);
+    };
+}`;
+
+  if (!common.includes(original)) {
+    throw new Error(`Could not find createRequestFunction in ${commonPath}`);
+  }
+
+  writeFileSync(commonPath, common.replace(original, replacement));
+}
+
 const dir = process.argv[2];
 if (!dir) {
   console.error("usage: patch.mjs <client-dir>");
@@ -88,6 +141,7 @@ const tsconfig = {
 writeFileSync(tsconfigPath, `${JSON.stringify(tsconfig, null, 2)}\n`);
 rmSync(tsconfigEsmPath, { force: true });
 
+patchAssetsApiClient(dir, pkg);
 addJsExtensions(dir);
 
 console.log(`patched ${dir}`);


### PR DESCRIPTION
The assets TypeScript SDK currently generates /v2/* requests against https://assets.deadlock-api.com. Those requests redirect to https://api.deadlock-api.com/v1/assets/*, which browsers can choke on as a cross-origin redirect.\n\nThis keeps raw asset endpoints on the assets host, but rewrites generated /v2/* SDK requests to the canonical API assets URL before Axios sends the request. The patch is applied from typescript/patch.mjs so regenerated assets clients keep the fix.